### PR TITLE
Fix: Deploy, one AZ, test config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ init: install assets
 	npm run bootstrap
 
 deploy: assets
-	npm run bootstrap
+	npm run deploy
 
 destroy: 
 	npm run destroy

--- a/lib/valheim-server-cdk-stack.ts
+++ b/lib/valheim-server-cdk-stack.ts
@@ -35,6 +35,7 @@ export class ValheimServerCdkStack extends cdk.Stack {
 
     /* VPC  */
     const vpc = new Vpc(this, 'VPC', {
+      maxAzs: 1
     });
 
     /* Security Group */

--- a/test/valheim-server-cdk.test.ts
+++ b/test/valheim-server-cdk.test.ts
@@ -10,7 +10,8 @@ test('EC2 Instance Created', () => {
     keyPairName: 'foo-key-pair-name',
     instanceSize: InstanceSize.LARGE,
     instanceClass: InstanceClass.T2,
-    backupS3BucketName: 'foo-backup-bucket-name'
+    backupS3BucketName: 'foo-backup-bucket-name',
+    worldName: 'FooWorldName'
   });
   // THEN
   expectCDK(stack).to(haveResource("AWS::EC2::Instance"));


### PR DESCRIPTION
Notes
* Fixes `make deploy` to run the deploy script
* Configures VPC to only use one AZ -- therefore there aren't additional unnecessary elastic IPs created
* Fixes test config so `make test` passes (need to hook up auto-running tests)