### PR TITLE
Fix: Existing S3 Bucket URL formulation

### DIFF
--- a/lib/valheim-server-cdk-stack.ts
+++ b/lib/valheim-server-cdk-stack.ts
@@ -80,7 +80,7 @@ export class ValheimServerCdkStack extends cdk.Stack {
     /* CloudFormation Initialization */
     let restoreFromS3Command;
     if (props.existingBucket) {
-      const src = path.join('s3://', props.backupS3BucketName, '/'),
+      const src = 's3://' + path.join(props.backupS3BucketName, '/'),
         dest = path.join(USER_VIKING_WORLDS_FOLDER_PATH, '/');
       restoreFromS3Command = InitCommand.argvCommand([
         'aws',


### PR DESCRIPTION
* Incorrectly uses `path.join(...)` with a URL protocol resulting in `s3:/...` instead of `s3://...`