### PR TITLE
add backup action and documentation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,36 @@
+# Github Action Documentation
+
+Create a personal access token if triggering from POST request:
+https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
+
+Action event workflow_dispatch documentation:
+https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch
+
+Create a workflow_dispatch event documentation:
+https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event
+
+Adding secrets to the repository:
+https://docs.github.com/en/actions/reference/encrypted-secrets
+
+## Inputs for valheim-server-cdk repo:
+
+### `AWS_REGION`
+
+**Required** A valid AWS region.
+
+### `AWS_ACCESS_KEY_ID`
+
+**Required** AWS Access key ID.
+
+### `AWS_SECRET_ACCESS_KEY`
+
+**Required** AWS Secret Access key.
+
+### `INSTANCE_ID`
+
+**Required** A single instance id or a list of ids seperated with new lines.
+
+## TODO
+ - Could have additional backup/update YAML workflow files per server, and slightly tweak the secret names and add additional secrets to the repository to manage different servers.
+
+ - Could create a workflow for the initial deploy of the server as well.

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,29 @@
+name: AWS SSM Send-Command Backup
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  start:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: AWS SSM Send-Command
+        uses: peterkimzz/aws-ssm-send-command@master
+        id: ssm
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          instance-ids: ${{ secrets.INSTANCE_ID }}
+
+          #TODO: update these values to point to the backup script
+          working-directory: /home/ec2-user/
+          command: ./stop_backup_start.sh
+          comment: StopBackupStart
+
+      # Catch SSM outputs
+      - name: Get the outputs
+        run: echo "The Command id is ${{ steps.ssm.outputs.command-id }}"


### PR DESCRIPTION
This adds the action to execute the stop_backup_start.sh file on the aws instance, and the documentation for which secrets to add to the repository to be able to connect to the aws instance. Incorporates comments from PR #9