### PR TITLE
Feature: console flag

### DIFF
--- a/templates/custom_start_valheim.sh.hbs
+++ b/templates/custom_start_valheim.sh.hbs
@@ -5,5 +5,5 @@ export SteamAppId=892970
 
 # Tip: Make a local copy of this script to avoid it being overwritten by steam.
 # NOTE: You need to make sure the ports 2456-2458 is being forwarded to your server through your local router & firewall.
-./valheim_server.x86_64 -name "{{displayName}}" -port 2456 -nographics -batchmode -world "{{worldName}}" -password "{{password}}"
+./valheim_server.x86_64 -name "{{displayName}}" -port 2456 -nographics -batchmode -world "{{worldName}}" -password "{{password}}" {{#if enableConsole}}-console{{/if}}
 export LD_LIBRARY_PATH=$templdpath

--- a/user-config.json.template
+++ b/user-config.json.template
@@ -5,5 +5,6 @@
     "keyPairName": "ENTER-YOUR-KEYPAIR-HERE",
     "instanceClass": "t2",
     "instanceSize": "medium",
-    "backupS3BucketName": "ENTER-YOUR-UNIQUE-BACKUP-BUCKET-NAME-HERE"
+    "backupS3BucketName": "ENTER-YOUR-UNIQUE-BACKUP-BUCKET-NAME-HERE",
+    "enableConsole": false
 }


### PR DESCRIPTION
* Allows `"enableConsole":true` to `user-config.json` to add `-console` flag to server start

### Testing
* Confirmed missing `-console` when...
  * `enableConsole` is missing from `user-config.json`
  * `enableConsole` is `false` within `user-config.json`
* Confirmed `-console` present when...
  * `enableConsole` is `true` within `user-config.json`